### PR TITLE
sha2: fix strict-aliasing compile error

### DIFF
--- a/sha2/sha2.c
+++ b/sha2/sha2.c
@@ -637,7 +637,9 @@ void dtls_sha256_final(sha2_byte digest[], dtls_sha256_ctx* context) {
 			*context->buffer = 0x80;
 		}
 		/* Set the bit count: */
-                *(sha2_word64*)(context->buffer+DTLS_SHA256_SHORT_BLOCK_LENGTH) = context->bitcount;
+		//*(sha2_word64*)(context->buffer+DTLS_SHA256_SHORT_BLOCK_LENGTH) = context->bitcount;
+		MEMCPY_BCOPY(context->buffer+DTLS_SHA256_SHORT_BLOCK_LENGTH,
+					 (void *)&context->bitcount, sizeof(context->bitcount));
 
 		/* Final transform: */
 		dtls_sha256_transform(context, (sha2_word32*)context->buffer);


### PR DESCRIPTION
fix error found in RIOT-OS/RIOT#8031:

```
sha2.c: In function 'dtls_sha256_final':
sha2.c:640:17: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
                 *(sha2_word64*)(context->buffer+DTLS_SHA256_SHORT_BLOCK_LENGTH) = context->bitcount;
                 ^
cc1: all warnings being treated as errors
```